### PR TITLE
Added meta tag to template to specify UTF-8 encoding

### DIFF
--- a/views/layout.php
+++ b/views/layout.php
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
     <head>
+        <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
         <title><?php echo APP_NAME ?></title>
         <base href="<?php echo BASE_URL; ?>/" />
 


### PR DESCRIPTION
so documents with accents are displayed properly.

For example, a markdown document with this content:

```
### Componentes de una página nueva
```

Would not display properly.
