### PR TITLE
Fix warning in tree.php on empty library folder

### DIFF
--- a/views/tree.php
+++ b/views/tree.php
@@ -27,7 +27,7 @@ function tree($array, $parent, $parts = array(), $step = 0) {
 }
 ?>
 
-<?php echo tree($this->_getTree(), BASE_URL, $parts); ?>
+<?php echo tree($this->_getTree(), BASE_URL, $parts, isset($parts) ? $parts : array()); ?>
 
 <script>
     $('#sidebar a[data-role="directory"]').click(function (event) {


### PR DESCRIPTION
Fix warning of undefined variable
