### PR TITLE
Use correct HTML5 charset tag

### DIFF
--- a/views/layout.php
+++ b/views/layout.php
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
     <head>
-        <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+        <meta charset="utf-8">
         <title><?php echo APP_NAME ?></title>
         <base href="<?php echo BASE_URL; ?>/">
 


### PR DESCRIPTION
The current charset meta-tag is incorrect for HTML5, this PR replaces it with the correct format:

```
<meta charset="utf-8">
```
