### PR TITLE
Fix bug when folder name is a number

### DIFF
--- a/wiki.php
+++ b/wiki.php
@@ -125,7 +125,7 @@ class Wiki
         uksort($return['directories'], "strnatcasecmp");
         uksort($return['files'], "strnatcasecmp");
 
-        return array_merge($return['directories'], $return['files']);
+        return $return['directories'] + $return['files'];
     }
 
     public function dispatch()


### PR DESCRIPTION
Folder names are handled as indexes. 
This is a problems when a folder is named with an integer.
