### PR TITLE
Remove 301 redirect after update of edited file

### DIFF
--- a/wiki.php
+++ b/wiki.php
@@ -374,12 +374,11 @@ class Wiki
             $this->_404();
         }
 
-        // Save the changes, and redirect back to the same page:
+        // Save the changes
         file_put_contents($path, $source);
 
-        $redirect_url = BASE_URL . "/$file";
-        header("HTTP/1.0 302 Found", true);
-        header("Location: $redirect_url");
+        // Now show the page
+        $this->indexAction();
 
         exit();
     }


### PR DESCRIPTION
Upon saving the changes to the edited file there was a superfluous redirect to the same page. I've simply replaced the redirect with a direct call to indexAction.

Was there a specific reason for this redirect?
