### PR TITLE
fix warning when index.md not exist

### DIFF
--- a/wiki.php
+++ b/wiki.php
@@ -331,7 +331,9 @@ class Wiki
                 return $this->_render('index.md');
             }
 
-            return $this->_view('index');
+            return $this->_view('index', array(
+            	'page' => $this->_default_page_data
+            ));
         }
 
         try {


### PR DESCRIPTION
On opening the main page when no index.md exist, multiple warnings are shown:

```
Notice: Undefined variable: page in /Wikitten/views/layout.php on line 12
```

etc.
