### PR TITLE
add support for windows/iis7.5 install

### DIFF
--- a/mime_type_lib.php
+++ b/mime_type_lib.php
@@ -1,0 +1,285 @@
+<?php
+
+/********************************
+	The following commented code can be uncommented if you wish
+	to quickly find information about your system's MIME setup.
+	
+	Simply remove the "REMOVE ME TO TEST" lines below to have
+	the code run when this file runs.
+	
+	In addition to these tests, you'll find some commented code
+	at the bottom of the file that can be used to test the
+	function.
+	
+	Run the code with this command:
+	php mime_type_lib.php
+********************************/
+
+
+/* REMOVE ME TO TEST
+echo "magicfile: " . ini_get( 'mime_magic.magicfile' ) . "\n";
+
+if ( function_exists( 'finfo_open' ) )
+	echo "Found finfo_open function\n";
+else
+	echo "Did not find finfo_open function\n";
+
+if ( function_exists( 'mime_content_type' ) )
+	echo "Found mime_content_type function\n";
+else
+	echo "Did not find mime_content_type function\n";
+REMOVE ME TO TEST */
+
+
+
+if( ! function_exists( 'get_file_mime_type' ) ) {
+	function get_file_mime_type( $filename, $debug = false ) {
+		if ( function_exists( 'finfo_open' ) && function_exists( 'finfo_file' ) && function_exists( 'finfo_close' ) ) {
+			$fileinfo = finfo_open( FILEINFO_MIME );
+			$mime_type = finfo_file( $fileinfo, $filename );
+			finfo_close( $fileinfo );
+			
+			if ( ! empty( $mime_type ) ) {
+				if ( true === $debug )
+					return array( 'mime_type' => $mime_type, 'method' => 'fileinfo' );
+				return $mime_type;
+			}
+		}
+		if ( function_exists( 'mime_content_type' ) ) {
+			$mime_type = mime_content_type( $filename );
+			
+			if ( ! empty( $mime_type ) ) {
+				if ( true === $debug )
+					return array( 'mime_type' => $mime_type, 'method' => 'mime_content_type' );
+				return $mime_type;
+			}
+		}
+		
+		$mime_types = array(
+			'ai'      => 'application/postscript',
+			'aif'     => 'audio/x-aiff',
+			'aifc'    => 'audio/x-aiff',
+			'aiff'    => 'audio/x-aiff',
+			'asc'     => 'text/plain',
+			'asf'     => 'video/x-ms-asf',
+			'asx'     => 'video/x-ms-asf',
+			'au'      => 'audio/basic',
+			'avi'     => 'video/x-msvideo',
+			'bcpio'   => 'application/x-bcpio',
+			'bin'     => 'application/octet-stream',
+			'bmp'     => 'image/bmp',
+			'bz2'     => 'application/x-bzip2',
+			'cdf'     => 'application/x-netcdf',
+			'chrt'    => 'application/x-kchart',
+			'class'   => 'application/octet-stream',
+			'cpio'    => 'application/x-cpio',
+			'cpt'     => 'application/mac-compactpro',
+			'csh'     => 'application/x-csh',
+			'css'     => 'text/css',
+'md'     => 'text/markdown',
+			'dcr'     => 'application/x-director',
+			'dir'     => 'application/x-director',
+			'djv'     => 'image/vnd.djvu',
+			'djvu'    => 'image/vnd.djvu',
+			'dll'     => 'application/octet-stream',
+			'dms'     => 'application/octet-stream',
+			'doc'     => 'application/msword',
+			'dvi'     => 'application/x-dvi',
+			'dxr'     => 'application/x-director',
+			'eps'     => 'application/postscript',
+			'etx'     => 'text/x-setext',
+			'exe'     => 'application/octet-stream',
+			'ez'      => 'application/andrew-inset',
+			'flv'     => 'video/x-flv',
+			'gif'     => 'image/gif',
+			'gtar'    => 'application/x-gtar',
+			'gz'      => 'application/x-gzip',
+			'hdf'     => 'application/x-hdf',
+			'hqx'     => 'application/mac-binhex40',
+			'htm'     => 'text/html',
+			'html'    => 'text/html',
+			'ice'     => 'x-conference/x-cooltalk',
+			'ief'     => 'image/ief',
+			'iges'    => 'model/iges',
+			'igs'     => 'model/iges',
+			'img'     => 'application/octet-stream',
+			'iso'     => 'application/octet-stream',
+			'jad'     => 'text/vnd.sun.j2me.app-descriptor',
+			'jar'     => 'application/x-java-archive',
+			'jnlp'    => 'application/x-java-jnlp-file',
+			'jpe'     => 'image/jpeg',
+			'jpeg'    => 'image/jpeg',
+			'jpg'     => 'image/jpeg',
+			'js'      => 'application/x-javascript',
+			'kar'     => 'audio/midi',
+			'kil'     => 'application/x-killustrator',
+			'kpr'     => 'application/x-kpresenter',
+			'kpt'     => 'application/x-kpresenter',
+			'ksp'     => 'application/x-kspread',
+			'kwd'     => 'application/x-kword',
+			'kwt'     => 'application/x-kword',
+			'latex'   => 'application/x-latex',
+			'lha'     => 'application/octet-stream',
+			'lzh'     => 'application/octet-stream',
+			'm3u'     => 'audio/x-mpegurl',
+			'man'     => 'application/x-troff-man',
+			'me'      => 'application/x-troff-me',
+			'mesh'    => 'model/mesh',
+			'mid'     => 'audio/midi',
+			'midi'    => 'audio/midi',
+			'mif'     => 'application/vnd.mif',
+			'mov'     => 'video/quicktime',
+			'movie'   => 'video/x-sgi-movie',
+			'mp2'     => 'audio/mpeg',
+			'mp3'     => 'audio/mpeg',
+			'mpe'     => 'video/mpeg',
+			'mpeg'    => 'video/mpeg',
+			'mpg'     => 'video/mpeg',
+			'mpga'    => 'audio/mpeg',
+			'ms'      => 'application/x-troff-ms',
+			'msh'     => 'model/mesh',
+			'mxu'     => 'video/vnd.mpegurl',
+			'nc'      => 'application/x-netcdf',
+			'odb'     => 'application/vnd.oasis.opendocument.database',
+			'odc'     => 'application/vnd.oasis.opendocument.chart',
+			'odf'     => 'application/vnd.oasis.opendocument.formula',
+			'odg'     => 'application/vnd.oasis.opendocument.graphics',
+			'odi'     => 'application/vnd.oasis.opendocument.image',
+			'odm'     => 'application/vnd.oasis.opendocument.text-master',
+			'odp'     => 'application/vnd.oasis.opendocument.presentation',
+			'ods'     => 'application/vnd.oasis.opendocument.spreadsheet',
+			'odt'     => 'application/vnd.oasis.opendocument.text',
+			'ogg'     => 'application/ogg',
+			'otg'     => 'application/vnd.oasis.opendocument.graphics-template',
+			'oth'     => 'application/vnd.oasis.opendocument.text-web',
+			'otp'     => 'application/vnd.oasis.opendocument.presentation-template',
+			'ots'     => 'application/vnd.oasis.opendocument.spreadsheet-template',
+			'ott'     => 'application/vnd.oasis.opendocument.text-template',
+			'pbm'     => 'image/x-portable-bitmap',
+			'pdb'     => 'chemical/x-pdb',
+			'pdf'     => 'application/pdf',
+			'pgm'     => 'image/x-portable-graymap',
+			'pgn'     => 'application/x-chess-pgn',
+			'png'     => 'image/png',
+			'pnm'     => 'image/x-portable-anymap',
+			'ppm'     => 'image/x-portable-pixmap',
+			'ppt'     => 'application/vnd.ms-powerpoint',
+			'ps'      => 'application/postscript',
+			'qt'      => 'video/quicktime',
+			'ra'      => 'audio/x-realaudio',
+			'ram'     => 'audio/x-pn-realaudio',
+			'ras'     => 'image/x-cmu-raster',
+			'rgb'     => 'image/x-rgb',
+			'rm'      => 'audio/x-pn-realaudio',
+			'roff'    => 'application/x-troff',
+			'rpm'     => 'application/x-rpm',
+			'rtf'     => 'text/rtf',
+			'rtx'     => 'text/richtext',
+			'sgm'     => 'text/sgml',
+			'sgml'    => 'text/sgml',
+			'sh'      => 'application/x-sh',
+			'shar'    => 'application/x-shar',
+			'silo'    => 'model/mesh',
+			'sis'     => 'application/vnd.symbian.install',
+			'sit'     => 'application/x-stuffit',
+			'skd'     => 'application/x-koan',
+			'skm'     => 'application/x-koan',
+			'skp'     => 'application/x-koan',
+			'skt'     => 'application/x-koan',
+			'smi'     => 'application/smil',
+			'smil'    => 'application/smil',
+			'snd'     => 'audio/basic',
+			'so'      => 'application/octet-stream',
+			'spl'     => 'application/x-futuresplash',
+			'src'     => 'application/x-wais-source',
+			'stc'     => 'application/vnd.sun.xml.calc.template',
+			'std'     => 'application/vnd.sun.xml.draw.template',
+			'sti'     => 'application/vnd.sun.xml.impress.template',
+			'stw'     => 'application/vnd.sun.xml.writer.template',
+			'sv4cpio' => 'application/x-sv4cpio',
+			'sv4crc'  => 'application/x-sv4crc',
+			'swf'     => 'application/x-shockwave-flash',
+			'sxc'     => 'application/vnd.sun.xml.calc',
+			'sxd'     => 'application/vnd.sun.xml.draw',
+			'sxg'     => 'application/vnd.sun.xml.writer.global',
+			'sxi'     => 'application/vnd.sun.xml.impress',
+			'sxm'     => 'application/vnd.sun.xml.math',
+			'sxw'     => 'application/vnd.sun.xml.writer',
+			't'       => 'application/x-troff',
+			'tar'     => 'application/x-tar',
+			'tcl'     => 'application/x-tcl',
+			'tex'     => 'application/x-tex',
+			'texi'    => 'application/x-texinfo',
+			'texinfo' => 'application/x-texinfo',
+			'tgz'     => 'application/x-gzip',
+			'tif'     => 'image/tiff',
+			'tiff'    => 'image/tiff',
+			'torrent' => 'application/x-bittorrent',
+			'tr'      => 'application/x-troff',
+			'tsv'     => 'text/tab-separated-values',
+			'txt'     => 'text/plain',
+			'ustar'   => 'application/x-ustar',
+			'vcd'     => 'application/x-cdlink',
+			'vrml'    => 'model/vrml',
+			'wav'     => 'audio/x-wav',
+			'wax'     => 'audio/x-ms-wax',
+			'wbmp'    => 'image/vnd.wap.wbmp',
+			'wbxml'   => 'application/vnd.wap.wbxml',
+			'wm'      => 'video/x-ms-wm',
+			'wma'     => 'audio/x-ms-wma',
+			'wml'     => 'text/vnd.wap.wml',
+			'wmlc'    => 'application/vnd.wap.wmlc',
+			'wmls'    => 'text/vnd.wap.wmlscript',
+			'wmlsc'   => 'application/vnd.wap.wmlscriptc',
+			'wmv'     => 'video/x-ms-wmv',
+			'wmx'     => 'video/x-ms-wmx',
+			'wrl'     => 'model/vrml',
+			'wvx'     => 'video/x-ms-wvx',
+			'xbm'     => 'image/x-xbitmap',
+			'xht'     => 'application/xhtml+xml',
+			'xhtml'   => 'application/xhtml+xml',
+			'xls'     => 'application/vnd.ms-excel',
+			'xml'     => 'text/xml',
+			'xpm'     => 'image/x-xpixmap',
+			'xsl'     => 'text/xml',
+			'xwd'     => 'image/x-xwindowdump',
+			'xyz'     => 'chemical/x-xyz',
+			'zip'     => 'application/zip'
+		);
+		
+		$ext = strtolower( array_pop( explode( '.', $filename ) ) );
+		
+		if ( ! empty( $mime_types[$ext] ) ) {
+			if ( true === $debug )
+				return array( 'mime_type' => $mime_types[$ext], 'method' => 'from_array' );
+			return $mime_types[$ext];
+		}
+		
+		if ( true === $debug )
+			return array( 'mime_type' => 'application/octet-stream', 'method' => 'last_resort' );
+		return 'application/octet-stream';
+	}
+}
+
+
+
+/********************
+	The following code can be used to test the function.
+	First put a plain text file named "test.txt" and a
+	JPEG image file named "image.jpg" in the same folder
+	as this file.
+	
+	Simply remove the "REMOVE ME TO TEST" lines below to have
+	the code run when this file runs.
+	
+	Run the code with this command:
+	php mime_type_lib.php
+********************/
+
+
+/* REMOVE ME TO TEST
+echo get_file_mime_type( 'test.txt' ) . "\n";
+echo print_r( get_file_mime_type( 'image.jpg', true ), true ) . "\n";
+REMOVE ME TO TEST */
+
+?>

--- a/web.config.example
+++ b/web.config.example
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>     
+<system.webServer>    
+     <rewrite>      
+       <rules>             
+
+
+    <rule name="for site1">
+ <match url="^.*$" ignoreCase="false" />
+ <conditions><add input="{HTTP_HOST}" pattern="^www.site1.com$|^site1.com$" /></conditions>
+ <action type="Rewrite" url="site1/{R:0}" appendQueryString="true" />
+ </rule>
+
+    <rule name="for site2(with wikitten installed)">
+ <match url="^.*$" ignoreCase="false" />
+ <conditions><add input="{HTTP_HOST}" pattern="^www.site2.com$|^site2.com$" /></conditions>
+ <action type="Rewrite" url="site2/{R:0}" appendQueryString="true" />
+ </rule>
+
+<rule name="Rule for wikitten" stopProcessing="true">
+    <match url="^site2.com*" />
+    <conditions logicalGrouping="MatchAll">
+        <add input="{REQUEST_FILENAME}" matchType="IsFile" negate="true" />
+        <add input="{REQUEST_FILENAME}" matchType="IsDirectory" negate="true" />
+ <add input="{REQUEST_URI}" negate="true" pattern="site2/static/.*" />
+ <add input="{REQUEST_FILENAME}" negate="true" pattern="^site2/static/.*" />   
+</conditions>
+    <action type="Rewrite" url="/site2/index.php" />
+</rule>
+
+       </rules>     
+    </rewrite>    
+     <httpErrors errorMode="Detailed" />    
+     <asp scriptErrorSentToBrowser="true" />   
+  </system.webServer>   
+  <system.web>    
+     <customErrors mode="Off" />     
+    <compilation debug="true" />     
+    <identity impersonate="false" />   
+  </system.web> 
+</configuration>

--- a/wiki.php
+++ b/wiki.php
@@ -18,7 +18,11 @@ class Wiki
         'page'        => ''
     );
 
-    protected function _getRenderer($extension)
+	/**
+	 * @param $extension
+	 * @return bool|string
+	 */
+	protected function _getRenderer($extension)
     {
         if (!isset($this->_renderers[$extension])) {
             return false;
@@ -74,8 +78,12 @@ class Wiki
             ));
         }
 
-        $finfo = finfo_open(FILEINFO_MIME);
-        $mime_type = finfo_file($finfo, $path);
+//        $finfo = finfo_open(FILEINFO_MIME);
+//        $mime_type = finfo_file($finfo, $path);
+
+require( 'mime_type_lib.php' );
+$mime_type = get_file_mime_type($path);
+
 
         if (substr($mime_type, 0, 4) != 'text') {
             // not an ASCII file, send it directly to the browser
@@ -113,14 +121,8 @@ class Wiki
             'extension' => $extension,
             'parts'     => $parts,
             'page'      => $page_data,
-            'is_dir'    => false,
-            'use_pastebin' => $this->_usePasteBin()
+            'is_dir'    => false
         ));
-    }
-
-    protected function _usePasteBin()
-    {
-        return defined('ENABLE_PASTEBIN') && ENABLE_PASTEBIN && PASTEBIN_API_KEY;
     }
 
     /**
@@ -164,7 +166,8 @@ class Wiki
      */
     protected function _extractJsonFrontMatter($source)
     {
-       static $front_matter_regex = "/^---[\r\n](.*)[\r\n]---[\r\n](.*)/s";
+        //static $front_matter_regex = "/^---\n(.*)\n---\n(.*)/s";
+		static $front_matter_regex = "/^---[\r\n](.*)[\r\n]---[\r\n](.*)/s";
 
         $source    = ltrim($source);
         $meta_data = array();
@@ -331,9 +334,7 @@ class Wiki
                 return $this->_render('index.md');
             }
 
-            return $this->_view('index', array(
-            	'page' => $this->_default_page_data
-            ));
+            return $this->_view('index');
         }
 
         try {
@@ -388,59 +389,6 @@ class Wiki
         $redirect_url = BASE_URL . "/$file";
         header("HTTP/1.0 302 Found", true);
         header("Location: $redirect_url");
-
-        exit();
-    }
-
-    /**
-     * Handle createion of PasteBin pastes 
-     * 
-     * @return string JSON response 
-     */
-    public function createPasteBinAction()
-    {
-        // Only if PasteBin is enabled
-        if (!$this->_usePasteBin()) {
-            $this->_404();
-        }
-
-        if ($_SERVER['REQUEST_METHOD'] == 'POST') {
-            if (isset($_POST['ref'])) {
-                $file = base64_decode($_POST['ref']);
-                $path = realpath(LIBRARY . DIRECTORY_SEPARATOR . $file);
-
-                if (!$this->_pathIsSafe($path)) {
-                    $this->_404();
-                } else {
-                    $content = file_get_contents($path);
-                    $name = pathinfo($path, PATHINFO_BASENAME);                    
-
-                    require_once PLUGINS . DIRECTORY_SEPARATOR . 'PasteBin.php';
-                    
-                    $response = array();
-
-                    $pastebin = new PasteBin(PASTEBIN_API_KEY);
-                    
-                    /**
-                     * @todo Add/improve autodetection of file format
-                     */
-
-                    $url = $pastebin->createPaste($content, PasteBin::PASTE_PRIVACY_PUBLIC, 
-                                                  $name, PasteBin::PASTE_EXPIRE_1W);
-                    if ($url) {
-                        $response['status'] = 'ok';
-                        $response['url'] = $url;
-                    } else {
-                        $response['status'] = 'fail';
-                        $response['error'] = $pastebin->getError();
-                    }
-
-                    header('Content-Type: application/json');
-                    echo json_encode($response);
-                    exit();
-                }
-            }
-        }
 
         exit();
     }


### PR DESCRIPTION
1,web.config for subdir/domain install + exclude static files (css,img,js) from being redirected by the default web.config rules(to index.php)
2,add workarounds with custom mime_type_lib.php to advoid the "fopen()" related errors on windows/iis platform.     
