### PR TITLE
added support for rendering LaTeX equations using MathJax

### DIFF
--- a/library/Sample Markdown document.md
+++ b/library/Sample Markdown document.md
@@ -20,6 +20,7 @@ Markdown: Syntax
 *   [Miscellaneous](#misc)
     *   [Backslash Escapes](#backslash)
     *   [Automatic Links](#autolink)
+    *   [\\(\rm\LaTeX\\) Mathematics](#latexmath)
 
 * * *
 
@@ -887,3 +888,26 @@ Markdown provides backslash escapes for the following characters:
     - minus sign (hyphen)
     .   dot
     !   exclamation mark
+
+<h3 id="latexmath">LaTeX Mathematics</h3>
+
+\\(\rm\LaTeX\\) is a markup language for typesetting books, reports, articles,
+presentations, and many other types of documents.
+It is popular in the quantitative sciences since it renders beautiful
+equations from relatively straightforward plaintext markup.
+\\(\rm\LaTeX\\) formatted equations can be inserted into Markdown and HTML documents;
+they will be rendered using the MathJax library.
+
+Note that the opening and closing backslashes must be escaped, but special characters
+in the equations do not need escaping. The following source:
+
+    This is an inline equation: \\({{x+y}\over{z}}=5\\).
+    This is a block equation: $${{x+y}\over{z}}=5$$
+    This is a block equation too: \\[{{x+y}\over{z}}=5\\]
+
+Renders to:
+
+This is an inline equation: \\({{x+y}\over{z}}=5\\).
+This is a block equation: $${{x+y}\over{z}}=5$$
+This is a block equation too: \\[{{x+y}\over{z}}=5\\]
+

--- a/views/layout.php
+++ b/views/layout.php
@@ -45,6 +45,7 @@ function e($dirty) {
         <script src="static/js/jquery.min.js"></script>
         <script src="static/js/prettify.js"></script>
         <script src="static/js/codemirror.min.js"></script>
+        <script type="text/javascript" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_CHTML"></script>
     </head>
 <body>
     <div id="main">


### PR DESCRIPTION
Used MathJax config that only supports TeX because that's all I need and it's more lightweight.

I see that other javascript libraries used in the code are included statically. Including a MathJax install instead of using the CDN version would be mildly complicated but I could be convinced to do it if that'd be more satisfactory.
