### PR TITLE
Reflect "LIBRARY" path in the config.php file to be reflected in the …

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -1,0 +1,1 @@
+HOST_LIBRARY=/path/to/markdown/files

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 config.php
+.env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,3 +4,4 @@ wikitten:
     - 9000:9000
   volumes:
     - .:/var/www
+    - ${HOST_LIBRARY}:/var/www/library


### PR DESCRIPTION
The current docker won't allow the user to have the markdown files outside the library folder, what does not complain with the `config.php` file:

```php
// Custom path to your wiki's library:
// define('LIBRARY', '/path/to/wiki/library');
```

This PR implements a `.env.dist` file with the `HOST_LIBRARY` parameter.

The user can copy it to a `.env` file and set the folder where the user has the markdown files to me mounted as the Wikitten library