### PR TITLE
Update bootstrap 4 pull-right

### DIFF
--- a/views/render.php
+++ b/views/render.php
@@ -2,7 +2,7 @@
     die('Forbidden!');
 } ?>
 <div class="breadcrumbs">
-    <div class="pull-right">
+    <div class="float-right">
         <?php if ($html && isset($source)): ?>
             <a href="javascript:;" class="btn-black" id="toggle">Toggle source</a>
         <?php endif ?>


### PR DESCRIPTION
Currently the layout suffers because pull-right has no actual class anymore:

![image](https://user-images.githubusercontent.com/32747235/70688469-29d80200-1cb2-11ea-8305-59b2ebd57a6c.png)

the migration guide suggests float-right as the alternative: https://getbootstrap.com/docs/4.0/migration/#utilities
